### PR TITLE
Refactor receipt parsing logic in VerifoneSPRemote.cs

### DIFF
--- a/VerifoneSPRemotePurchaseTerminalIntegration.Lib/VerifoneSPRemote.cs
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Lib/VerifoneSPRemote.cs
@@ -336,9 +336,13 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Lib
                     {
                         var receiptPosIdentification = message.Substring(26, 8);
 
-                        var receiptStrings = message.Substring(198).Split(new[] { (char)0x01 }, StringSplitOptions.None);
+                        var messagedSubString = message.Substring(198);
+                        var receiptStrings = messagedSubString.Split(new[] { (char)0x01 }, StringSplitOptions.None);
                         var merchantReceipt = string.Empty;
                         var clientReceipt = string.Empty;
+
+                        if (receiptStrings.Length >= 1)
+                            receiptStrings = messagedSubString.Split(new[] { (char)0x02 }, StringSplitOptions.None);
 
                         if (receiptStrings.Length >= 2)
                         {


### PR DESCRIPTION
Refactored `message` substring handling for improved readability by introducing `messagedSubString`. Enhanced `receiptStrings` parsing logic to conditionally re-split using `(char)0x02` if the array has at least one element, adding flexibility in delimiter handling. Maintained backward compatibility for `merchantReceipt` and `clientReceipt` processing.