### PR TITLE
Refactor substring handling and add conditional splitting

### DIFF
--- a/VerifoneSPRemotePurchaseTerminalIntegration.Lib/VerifoneSPRemote.cs
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Lib/VerifoneSPRemote.cs
@@ -415,9 +415,13 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Lib
 
                     var receiptPosIdentification = message.Substring(26, 8);
 
-                    var receiptStrings = message.Substring(77).Split(new[] { (char)0x01 }, StringSplitOptions.None);
+                    var messagedSubString = message.Substring(77);
+                    var receiptStrings = messagedSubString.Split(new[] { (char)0x01 }, StringSplitOptions.None);
                     var merchantReceipt = string.Empty;
                     var clientReceipt = string.Empty;
+
+                    if (receiptStrings.Length >= 1)
+                        receiptStrings = messagedSubString.Split(new[] { (char)0x02 }, StringSplitOptions.None);
 
                     if (receiptStrings.Length >= 2)
                     {


### PR DESCRIPTION
Refactor `message.Substring(77)` into `messagedSubString` to improve readability and reduce redundancy. Add a new conditional block to split `messagedSubString` with a different delimiter `(char)0x02` when `receiptStrings.Length
>= 1`. Preserve existing logic for `merchantReceipt` and
`clientReceipt` processing with updated `receiptStrings`.