### PR TITLE
Add purchase response parsing and refactor logic

### DIFF
--- a/VerifoneSPRemotePurchaseTerminalIntegration.Console/Program.cs
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Console/Program.cs
@@ -17,7 +17,7 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Console
 
         #region "Members"
 
-        private static readonly string serverIp = "192.168.40.175";
+        private static readonly string serverIp = "192.168.40.108";
         private static readonly int port = 5005;
 
         private static VerifoneSPRemote VerifoneSPRemote = null;
@@ -84,6 +84,9 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Console
                             else
                                 VerifoneSPRemote.Refund((PurchaseResult)lastProcessPaymentResult.ExtraData);
                             break;
+                        case TerminalCommandOptions.ParsePurchaseResponse:
+                            ParsePurchaseResponse();
+                            break;
                         case TerminalCommandOptions.ShowListOfCommands:
                             ShowListOfCommands();
                             break;
@@ -111,6 +114,17 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Console
                 System.Console.WriteLine($"   {(int)command} - {Utilities.GetEnumDescription(command)}");
             }
             System.Console.WriteLine();
+        }
+
+        private static void ParsePurchaseResponse()
+        {
+            System.Console.WriteLine("Insert a valid message...");
+
+            var input = System.Console.ReadLine()?.ToLower();
+
+            var res = VerifoneSPRemote.ParsePurchaseResponse(false, new PurchaseResult(), input);
+
+            System.Console.WriteLine(Newtonsoft.Json.JsonConvert.SerializeObject(res, Newtonsoft.Json.Formatting.Indented));
         }
 
         #endregion

--- a/VerifoneSPRemotePurchaseTerminalIntegration.Console/VerifoneSPRemotePurchaseTerminalIntegration.Console.csproj
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Console/VerifoneSPRemotePurchaseTerminalIntegration.Console.csproj
@@ -33,6 +33,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.7.7\lib\net45\NLog.dll</HintPath>
     </Reference>

--- a/VerifoneSPRemotePurchaseTerminalIntegration.Console/packages.config
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Console/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="NLog" version="4.7.7" targetFramework="net472" />
 </packages>

--- a/VerifoneSPRemotePurchaseTerminalIntegration.Lib/Enums.cs
+++ b/VerifoneSPRemotePurchaseTerminalIntegration.Lib/Enums.cs
@@ -16,6 +16,8 @@ namespace VerifoneSPRemotePurchaseTerminalIntegration.Lib
             SendProcessPaymentRequest = 4,
             [Description("Send terminal refund request")]
             SendProcessRefundRequest = 5,
+            [Description("Parse purchase response")]
+            ParsePurchaseResponse = 6,
             [Description("Show list of commands")]
             ShowListOfCommands = 9998,
             [Description("Stop listening")]


### PR DESCRIPTION
Introduce a new feature to parse purchase responses, including:
- Added `ParsePurchaseResponse` method in `Program.cs` for user input processing and JSON output.
- Added `ParsePurchaseResponse` enum value in `Enums.cs`.
- Refactored receipt parsing logic into `ParsePurchaseResponse` in `VerifoneSPRemote.cs` for modularity.
- Adjusted receipt parsing to handle `receiptStrings.Length == 1`.

Updated `serverIp` in `Program.cs` and added `Newtonsoft.Json` dependency in `VerifoneSPRemotePurchaseTerminalIntegration.Console.csproj` and `packages.config` for JSON serialization.